### PR TITLE
Enable opt-out minimize

### DIFF
--- a/lib/node-handlebars.js
+++ b/lib/node-handlebars.js
@@ -32,6 +32,8 @@ function NodeHandlebars(config) {
   this.extname     = config.extname || this.extname;
   this.layoutsDir  = config.layoutsDir || this.layoutsDir;
   this.partialsDir = config.partialsDir || this.partialsDir;
+  this.minimize    = typeof config.minimize !== 'undefined' ?
+                       config.minimize : true;
 
   this.handlebarsVersion = NodeHandlebars.getHandlebarsSemver(this.handlebars);
 
@@ -190,9 +192,9 @@ NodeHandlebars.prototype.render = function(filePath, context, options) {
     var template = templates[0];
     var partials = templates[1];
     var data     = options.data;
-    
+
     var helpers = options.helpers || utils.extend({}, this.handlebars.helpers, this.helpers);
-    
+
     return this._renderTemplate(template, context, {
       data: data,
       helpers: helpers,
@@ -225,18 +227,20 @@ NodeHandlebars.prototype.renderView = function(viewPath, options, callback) {
   this.render(viewPath, context, options)
     .then(function(body) {
       var layoutPath = this._resolveLayoutPath(options.layout);
-      
+
       if (layoutPath) {
         context = utils.extend({}, context, {
           body: body
         });
         return this.render(layoutPath, context, options);
       }
-      
-      minimize.parse(body, function (err, data) {
-        body = data;
-      });
-      
+
+      if(this.minimize){
+        minimize.parse(body, function (err, data) {
+          body = data;
+        });
+      }
+
       return body;
     }.bind(this))
     .then(utils.passValue(callback))

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-handlebars",
-  "version": "0.9.5",
+  "version": "0.9.6",
   "description": "Nodejs Handlebars with helpers",
   "main": "index.js",
   "dependencies": {


### PR DESCRIPTION
Enables preservation of whitespace. Useful for when using Handlebars for templating JavaScript files.
